### PR TITLE
statusnotified dbus, all devices

### DIFF
--- a/info.mumble.Mumble.yml
+++ b/info.mumble.Mumble.yml
@@ -11,9 +11,10 @@ finish-args:
   - --socket=x11
   - --socket=wayland
   - --socket=pulseaudio
-  - --device=dri
+  - --device=all
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
+  - --own-name=org.kde.StatusNotifierItem-2-2
 separate-locales: false
 cleanup:
   - /usr/include


### PR DESCRIPTION
Adds tray support and device support for input (see [mumble linux readme](https://github.com/mumble-voip/mumble/blob/master/README.Linux))